### PR TITLE
Fixed MacOS Virtual Media and keyboard issue

### DIFF
--- a/iDRAC6VirtualConsoleLauncher.py
+++ b/iDRAC6VirtualConsoleLauncher.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
         BINARYEX = '.exe'
     elif sys.platform.startswith('darwin'):
         PLATFORM = 'Mac64'
-        DYNLIBEX = '.so'
+        DYNLIBEX = '.jnilib'
         BINARYEX = ''
     else:
         print('Unsupported platform.')


### PR DESCRIPTION
The MacOS extension extracted from the KVM jar is jnilib. Validated on Catalina with my r510/iDRAC6. I did a full install of RHEL6 from a DVD iso virtual mount with no issue.